### PR TITLE
FIX: Select-kit components are now co-located

### DIFF
--- a/javascripts/discourse/components/locale-combo-box-header.js
+++ b/javascripts/discourse/components/locale-combo-box-header.js
@@ -1,11 +1,9 @@
 import { and, reads } from "@ember/object/computed";
 import SingleSelectHeaderComponent from "select-kit/components/select-kit/single-select-header";
 import { computed } from "@ember/object";
-import layout from "select-kit/templates/components/combo-box/combo-box-header";
 import discourseComputed from "discourse-common/utils/decorators";
 
 export default SingleSelectHeaderComponent.extend({
-  layout,
   classNames: ["combo-box-header"],
   clearable: reads("selectKit.options.clearable"),
   caretUpIcon: reads("selectKit.options.caretUpIcon"),


### PR DESCRIPTION
Addresses the change in https://github.com/discourse/discourse/commit/b3e063bc63dfc1b5d6c3808a495e2408bd59b4fe#diff-0ad9dc95445874f25598d33dac54ce7d2c5071da7a78d6202580607ebc00792c