### PR TITLE
FIX: import gte instead of using computed dot access

### DIFF
--- a/javascripts/discourse/components/locale-combo-box.js
+++ b/javascripts/discourse/components/locale-combo-box.js
@@ -1,5 +1,5 @@
 import SingleSelectComponent from "select-kit/components/single-select";
-import { computed } from "@ember/object";
+import { gte } from "@ember/object/computed";
 
 export default SingleSelectComponent.extend({
   pluginApiIdentifiers: ["combo-box"],
@@ -13,7 +13,7 @@ export default SingleSelectComponent.extend({
     headerComponent: "locale-combo-box-header",
   },
 
-  autoFilterable: computed.gte("content.length", 10),
+  autoFilterable: gte("content.length", 10),
 
   modifyComponentForRow() {
     return "locale-combo-box-row";


### PR DESCRIPTION
Ember 5 does not support computed dot access.